### PR TITLE
Extend local forecast entries

### DIFF
--- a/Scripts/twc1.js
+++ b/Scripts/twc1.js
@@ -2029,7 +2029,7 @@ var WeatherLocalForecast = function (WeatherForecastParser)
 
     $(WeatherForecastParser.Text).each(function (Index, Text)
     {
-        if (Index > 2)
+        if (Index > 4)
         {
             return false;
         }
@@ -2068,10 +2068,19 @@ if (!String.prototype.endsWith)
 
 var PopulateLocalForecast = function (WeatherLocalForecast)
 {
-    $(WeatherLocalForecast.Conditions).each(function (Index, Condition)
+    for (var Index = 0; Index < 5; Index++)
     {
-        $("#divLocalForecast" + (Index + 1)).html(Condition.DayName.toUpperCase() + "..." + Condition.Text.toUpperCase());
-    });
+        var div = $("#divLocalForecast" + (Index + 1));
+        if (Index < WeatherLocalForecast.Conditions.length)
+        {
+            var Condition = WeatherLocalForecast.Conditions[Index];
+            div.html(Condition.DayName.toUpperCase() + "..." + Condition.Text.toUpperCase());
+        }
+        else
+        {
+            div.html("");
+        }
+    }
 };
 
 var WeatherHazardsParser = function (html)

--- a/twc1.html
+++ b/twc1.html
@@ -146,6 +146,16 @@
                     <div id="divLocalForecast3"></div>
                 </td>
             </tr>
+            <tr>
+                <td>
+                    <div id="divLocalForecast4"></div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <div id="divLocalForecast5"></div>
+                </td>
+            </tr>
         </tbody>
     </table>
     <br />

--- a/twc3.html
+++ b/twc3.html
@@ -196,6 +196,16 @@
                         <div id="divLocalForecast3"></div>
                     </td>
                 </tr>
+                <tr>
+                    <td>
+                        <div id="divLocalForecast4"></div>
+                    </td>
+                </tr>
+                <tr>
+                    <td>
+                        <div id="divLocalForecast5"></div>
+                    </td>
+                </tr>
             </tbody>
         </table>
         <br />


### PR DESCRIPTION
## Summary
- show up to five local forecast periods
- display additional forecast rows on twc1 and twc3 pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d2bd8ed1483239f08f5dc00980090